### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python Main.py"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
   A text based RPG game with a story, shopping, NPC's, crafting, fighting and a ever grouping map to explore!
 
+  [![Run on Repl.it](https://repl.it/badge/github/cowboy8625/WordRPG)](https://repl.it/github/cowboy8625/WordRPG)
+
 ## Find Me Here
 If you are playing the game feel free to message me on [discord](https://discord.gg/8bkzqfm) about bugs or ideas
 or for any thing else!


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/WordRPG).